### PR TITLE
Fetch package version at runtime w/setuptools

### DIFF
--- a/flake8_quotes.py
+++ b/flake8_quotes.py
@@ -1,11 +1,10 @@
-import os
 import tokenize
 
 import pep8
+import pkg_resources
 
 
-with open(os.path.join(os.path.dirname(__file__), 'VERSION'), 'r') as handle:
-    __version__ = handle.read().strip()
+__version__ = pkg_resources.get_distribution('flake8_quotes').version
 
 
 class QuoteChecker(object):


### PR DESCRIPTION
The `VERSION` file contains the flake8_quotes version number. This file is
included with the project when its repository is cloned by virtue of being under
source control, and it is included in installable packages by virtue of being
mentioned in `MANIFEST.in`. However, this file is never actually installed. Only
files within the `flake8_quotes` namespace are available after installation.

This is problematic because the `flake8_quotes` module includes a reference to
this file. Installing flake8_quotes and then importing said module will trigger
an import error, as the `VERSION` file is unavailable after installation. Fix
this issue by doing the following to module `flake8_quotes`:

1. Drop the reference to the `VERSION` file.
2. Use setuptools to load the version number (from `metadata.json`).