### PR TITLE
Update supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "2.7"
   - "3.3"
+  - "3.4"
+  - "3.5"
 
 install:
   # Install our dependencies

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Quality Assurance',
     ]


### PR DESCRIPTION
Currently, Travis tests flake8_quotes under Python 3.3, and `setup.py` declares
flake8_quotes as being available for Python 3.4. Address this discrepancy by
making Travis test flake8_quotes under Python 3.3 – Python 3.5, and listing the
same set of versions in `setup.py`.