### PR TITLE
Rename quotes option

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -9,7 +9,7 @@ class QuoteChecker(object):
     name = __name__
     version = __version__
 
-    QUOTES = {
+    INLINE_QUOTES = {
         # When user wants only single quotes
         '\'': {
             'good_single': '\'',

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -30,13 +30,13 @@ class QuoteChecker(object):
 
     @classmethod
     def add_options(cls, parser):
-        parser.add_option('--quotes', default='\'', action='store',
+        parser.add_option('--quotes', default='\'', action='store', dest='inline_quotes',
                           help='Quote to expect in all files (default: \')')
         parser.config_options.append('quotes')
 
     @classmethod
     def parse_options(cls, options):
-        cls.quotes = cls.QUOTES[options.quotes]
+        cls.inline_quotes = cls.INLINE_QUOTES[options.inline_quotes]
 
     def get_file_contents(self):
         if self.filename in ('stdin', '-', None):
@@ -68,15 +68,15 @@ class QuoteChecker(object):
                 # ignore non strings
                 continue
 
-            if not token.string.startswith(self.quotes['bad_single']):
+            if not token.string.startswith(self.inline_quotes['bad_single']):
                 # ignore strings that do not start with our quotes
                 continue
 
-            if token.string.startswith(self.quotes['bad_multiline']):
+            if token.string.startswith(self.inline_quotes['bad_multiline']):
                 # ignore multiline strings
                 continue
 
-            if self.quotes['good_single'] in token.string:
+            if self.inline_quotes['good_single'] in token.string:
                 # ignore alternate quotes wrapped in our quotes (e.g. `'` in `"it's"`)
                 continue
 

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -30,8 +30,8 @@ class QuoteChecker(object):
 
     @classmethod
     def add_options(cls, parser):
-        parser.add_option('--quotes', default='\'', action='store', dest='inline_quotes',
-                          help='Quote to expect in all files (default: \') (deprecated)')
+        parser.add_option('--quotes', action='store', dest='inline_quotes',
+                          help='Deprecated alias for `--inline-quotes`')
         parser.add_option('--inline-quotes', default='\'', action='store',
                           help='Quote to expect in all files (default: \')')
         parser.config_options.append('quotes')

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -30,7 +30,7 @@ class QuoteChecker(object):
 
     @classmethod
     def add_options(cls, parser):
-        parser.add_option('--quotes', action='store', dest='inline_quotes',
+        parser.add_option('--quotes', action='store',
                           help='Deprecated alias for `--inline-quotes`')
         parser.add_option('--inline-quotes', default='\'', action='store',
                           help='Quote to expect in all files (default: \')')

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -34,7 +34,7 @@ class QuoteChecker(object):
                           help='Deprecated alias for `--inline-quotes`')
         parser.add_option('--inline-quotes', default='\'', action='store',
                           help='Quote to expect in all files (default: \')')
-        parser.config_options.append('quotes')
+        parser.config_options.extend(['quotes', 'inline-quotes'])
 
     @classmethod
     def parse_options(cls, options):

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -38,7 +38,7 @@ class QuoteChecker(object):
 
     @classmethod
     def parse_options(cls, options):
-        if hasattr(options, 'quotes'):
+        if hasattr(options, 'quotes') and options.quotes is not None:
             cls.inline_quotes = cls.INLINE_QUOTES[options.quotes]
         else:
             cls.inline_quotes = cls.INLINE_QUOTES[options.inline_quotes]

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -31,6 +31,8 @@ class QuoteChecker(object):
     @classmethod
     def add_options(cls, parser):
         parser.add_option('--quotes', default='\'', action='store', dest='inline_quotes',
+                          help='Quote to expect in all files (default: \') (deprecated)')
+        parser.add_option('--inline-quotes', default='\'', action='store',
                           help='Quote to expect in all files (default: \')')
         parser.config_options.append('quotes')
 

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -38,7 +38,10 @@ class QuoteChecker(object):
 
     @classmethod
     def parse_options(cls, options):
-        cls.inline_quotes = cls.INLINE_QUOTES[options.inline_quotes]
+        if not hasattr(options, 'inline_quotes') and hasattr(options, 'quotes'):
+            cls.inline_quotes = cls.INLINE_QUOTES[options.quotes]
+        else:
+            cls.inline_quotes = cls.INLINE_QUOTES[options.inline_quotes]
 
     def get_file_contents(self):
         if self.filename in ('stdin', '-', None):

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -38,7 +38,7 @@ class QuoteChecker(object):
 
     @classmethod
     def parse_options(cls, options):
-        if not hasattr(options, 'inline_quotes') and hasattr(options, 'quotes'):
+        if hasattr(options, 'quotes'):
             cls.inline_quotes = cls.INLINE_QUOTES[options.quotes]
         else:
             cls.inline_quotes = cls.INLINE_QUOTES[options.inline_quotes]

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -12,7 +12,7 @@ class TestChecks(TestCase):
 class DoublesTestChecks(TestCase):
     def setUp(self):
         class DoublesOptions():
-            quotes = '\''
+            inline_quotes = '\''
         QuoteChecker.parse_options(DoublesOptions)
 
     def test_multiline_string(self):
@@ -37,7 +37,7 @@ class DoublesTestChecks(TestCase):
 class SinglesTestChecks(TestCase):
     def setUp(self):
         class SinglesOptions():
-            quotes = '"'
+            inline_quotes = '"'
         QuoteChecker.parse_options(SinglesOptions)
 
     def test_multiline_string(self):


### PR DESCRIPTION
Rename `--quotes` to `--inline-quotes` as suggested in #26.

I'm not too sure if the best way to mark it as deprecated is to just put "(deprecated)" after the command, what do you think @twolfson?