### PR TITLE
Replace deprecated pep8 package with pycodestyle

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -1,7 +1,7 @@
 import tokenize
 import warnings
 
-import pep8
+import pycodestyle
 
 from flake8_quotes.__about__ import __version__
 
@@ -49,9 +49,9 @@ class QuoteChecker(object):
 
     def get_file_contents(self):
         if self.filename in ('stdin', '-', None):
-            return pep8.stdin_get_value().splitlines(True)
+            return pycodestyle.stdin_get_value().splitlines(True)
         else:
-            return pep8.readlines(self.filename)
+            return pycodestyle.readlines(self.filename)
 
     def run(self):
         file_contents = self.get_file_contents()

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='zheller@gmail.com',
     version=about['__version__'],
     install_requires=[
-        'pep8',
+        'pycodestyle',
     ],
     url='http://github.com/zheller/flake8-quotes/',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
fix for issue #30, where the pep8 package doesn't work with parsing python files on stdin anymore.