### PR TITLE
Ignore string prefixes like "b" or "u"

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -77,15 +77,22 @@ class QuoteChecker(object):
                 # ignore non strings
                 continue
 
-            if not token.string.startswith(self.inline_quotes['bad_single']):
+            # Remove any prefixes in strings like `u"foo"`. Use the quote
+            # character at the end of the string to know where the prefixes end
+            quote_char = token.string[-1]  # Does only contain one character!
+            quote_start = token.string.index(quote_char)
+            text = token.string[quote_start:]
+            # `"foo"`, `b"foo"`, `br"foo"` all result in `"foo"`
+
+            if not text.startswith(self.inline_quotes['bad_single']):
                 # ignore strings that do not start with our quotes
                 continue
 
-            if token.string.startswith(self.inline_quotes['bad_multiline']):
+            if text.startswith(self.inline_quotes['bad_multiline']):
                 # ignore multiline strings
                 continue
 
-            if self.inline_quotes['good_single'] in token.string:
+            if self.inline_quotes['good_single'] in text:
                 # ignore alternate quotes wrapped in our quotes (e.g. `'` in `"it's"`)
                 continue
 

--- a/test/data/doubles.py
+++ b/test/data/doubles.py
@@ -1,1 +1,3 @@
 this_should_be_linted = "double quote string"
+this_should_be_linted = u"double quote string"
+this_should_be_linted = br"double quote string"  # use b instead of u, as ur is invalid in Py3

--- a/test/data/singles.py
+++ b/test/data/singles.py
@@ -1,1 +1,3 @@
 this_should_be_linted = 'single quote string'
+this_should_be_linted = u'double quote string'
+this_should_be_linted = br'double quote string'  # use b instead of u, as ur is invalid in Py3

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -26,7 +26,9 @@ class DoublesTestChecks(TestCase):
     def test_doubles(self):
         doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles.py'))
         self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
-            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes.'}
+            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes.'},
         ])
 
     def test_noqa_doubles(self):
@@ -51,7 +53,9 @@ class SinglesTestChecks(TestCase):
     def test_singles(self):
         singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles.py'))
         self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
-            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes.'}
+            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes.'},
         ])
 
     def test_noqa_singles(self):


### PR DESCRIPTION
When the string uses prefixes, the checker wasn't checking those strings, because it only handles strings that start with a bad quote. To handle this, it gets the last character of the string (which is the quote character used) and removes all characters in front of the first quote character.

It also adds a few tests using one or two prefixes.

This is an implementation for #28.