### PR TITLE
Support multiline quote check

### DIFF
--- a/test/data/doubles_multiline_string.py
+++ b/test/data/doubles_multiline_string.py
@@ -1,7 +1,7 @@
-""" This "should"
-"not" be
+""" This "must"
+be
 "linted" """
 
 ''' This "should"
 "not" be
-linted "either" '''
+linted '''

--- a/test/data/singles_multiline_string.py
+++ b/test/data/singles_multiline_string.py
@@ -1,7 +1,7 @@
-''' This 'should'
-'not' be
+''' This 'must'
+be
 'linted' '''
 
 """ This 'should'
 'not' be
-linted 'either' """
+linted """

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -13,11 +13,14 @@ class DoublesTestChecks(TestCase):
     def setUp(self):
         class DoublesOptions():
             inline_quotes = '\''
+            multiline_quotes = None
         QuoteChecker.parse_options(DoublesOptions)
 
     def test_multiline_string(self):
         doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_multiline_string.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [])
+        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
+            {'col': 0, 'line': 1, 'message': 'Q001 Wrong multiline quote style used'},
+        ])
 
     def test_wrapped(self):
         doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_wrapped.py'))
@@ -40,11 +43,14 @@ class SinglesTestChecks(TestCase):
     def setUp(self):
         class SinglesOptions():
             inline_quotes = '"'
+            multiline_quotes = None
         QuoteChecker.parse_options(SinglesOptions)
 
     def test_multiline_string(self):
         singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_multiline_string.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [])
+        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
+            {'col': 0, 'line': 1, 'message': 'Q001 Wrong multiline quote style used'},
+        ])
 
     def test_wrapped(self):
         singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_wrapped.py'))


### PR DESCRIPTION
This also checks multiline quotes which can be configured separately. It also uses a different error code, so that repositories which don't want to use that new feature can just add the code to the ignored ones.

This is another implementation fixing #25 similar to #26 (the additional tests from there could be transferred). The main reason for this pull request is that it removes the need for the dictionaries. It also does not complain when the string contains the wanted quote also in the multiline mode (not 100% sure how the other patch handles that), by using the same idea for both variants.

There are a few things to mention:
- The messages for Q000 and Q001 are very different because I don't think that the current message “Remove bad quotes” is very descriptive. But for backwards compatibility I left the current message.
- ~~I'd prefer if #32 could be merged first. This is the reason for `text = token.string`.~~
- ~~It changes code which would need to be overhauled when support for flake8 v3 is implemented (see #29 and #34). If possible this should be merged after it (especially as fixing #29 isn't that complex).~~
