### PR TITLE
Added test for Flake8 3.x in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,17 @@ language: python
 python:
   - "2.7"
   - "3.3"
+matrix:
+  include:
+    - python: "3.3"
+      env: FLAKE8_VERSION=3
 
 install:
   # Install our dependencies
   - pip install -r requirements-dev.txt
+
+  # If we are testing Flake8 3.x, then install it
+  - if test "$FLAKE8_VERSION" = "3"; then pip install flake8==3.0.0b2; fi
 
   # Install `flake8-quotes`
   - python setup.py develop


### PR DESCRIPTION
We now support Flake8@3 as of `0.5.0` via #34. In this PR:

- Added tests to verify Flake8 3.x is properly supported and won't break

/cc @zheller @xZise 