### PR TITLE
Support stdin in Flake8

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -2,7 +2,7 @@ import optparse
 import tokenize
 import warnings
 
-import pep8
+from flake8.engine import pep8
 
 from flake8_quotes.__about__ import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='zheller@gmail.com',
     version=about['__version__'],
     install_requires=[
-        'pep8',
+        'flake8',
     ],
     url='http://github.com/zheller/flake8-quotes/',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Use Flake8's pep8
---
As mentioned in #30 using `stdin` doesn't work anymore. Now I don't know what the original issue was, but the issue I got can be fixed by using Flake8's `pep8` package. As far as I can tell the reason behind the error is that this plugin uses the original `pep8` package while Flake8 uses `pycodestyle`. 

And when Flake8/pycodestyle reads the content from `stdin`, it gets cached to future calls return the cached value and not an empty string. But when now pep8 reads from `stdin` it reads nothing, because everything was already read from the other package.

Empty result in Flake8 3.x
---
Additionally with Flake8 3.x it seems that it doesn't use pycodestyle's implementation at all anymore. Instead Flake8 itself first reads the content and caches it. But this now causes the fix to return an empty string.

Using Flake8 3.x features to get actual content
---
To avoid this it can use the utilities provided by Flake8 itself. It'll read the parameters of the constructors and automatically provide the values “requested” and there we can request the content.

Unfortunately this doesn't work in Flake8 2.x, so it only exposes the constructor that it expects and in Flake8 2.x the plugin itself reads the content like the original patch.

Alternative ideas
---
An alternative would be to requests the tokens already and not the lines itself. Another alternative is in xZise/flake8-quotes@b983f66, but to be honest I actually don't know if I tested that version.

Also I can separate the two patches, so that it can first fix `stdin` and then actually support also Flake8 3.x (as that is not stable yet it isn't as important afaik).

**Note**: This will change the dependency from pep8 to flake8! It might not be something you want.