### PR TITLE
Repaired stdin support by moving from `pep8` to `flake8`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ install:
   - pip install -r requirements-dev.txt
 
   # If we are testing Flake8 3.x, then install it
-  - if test "$FLAKE8_VERSION" = "3"; then
-      pip install flake8==3.0.0b2;
-    fi
+  - if test "$FLAKE8_VERSION" = "3"; then pip install flake8==3.0.0b2; fi
 
   # Install `flake8-quotes`
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,13 @@ install:
   - pip install -r requirements-dev.txt
 
   # If we are testing Flake8 3.x, then install it
-  - if test "$FLAKE8_VERSION" = "3"; then pip install flake8==3.0.0b2; fi
+  # Force jobs to 1 as a workaround to avoid the PicklingError
+  # see https://gitlab.com/pycqa/flake8/issues/164
+  - if test "$FLAKE8_VERSION" = "3"; then
+      pip install flake8==3.0.0b2;
+      echo "[flake8]" > tox.ini;
+      echo "jobs=1" >> tox.ini;
+    fi
 
   # Install `flake8-quotes`
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,8 @@ install:
   - pip install -r requirements-dev.txt
 
   # If we are testing Flake8 3.x, then install it
-  # Force jobs to 1 as a workaround to avoid the PicklingError
-  # see https://gitlab.com/pycqa/flake8/issues/164
   - if test "$FLAKE8_VERSION" = "3"; then
       pip install flake8==3.0.0b2;
-      echo "[flake8]" > tox.ini;
-      echo "jobs=1" >> tox.ini;
     fi
 
   # Install `flake8-quotes`

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -2,7 +2,7 @@ import optparse
 import tokenize
 import warnings
 
-import pep8
+from flake8.engine import pep8
 
 from flake8_quotes.__about__ import __version__
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length = 120
+# Force jobs to 1 as a workaround to avoid the PicklingError in Flake8 3.x
+# see https://gitlab.com/pycqa/flake8/issues/164
+jobs=1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='zheller@gmail.com',
     version=about['__version__'],
     install_requires=[
-        'pep8',
+        'flake8',
     ],
     url='http://github.com/zheller/flake8-quotes/',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
Instead of relying on `pep8` importing itself, it can just use Flake8's `pep8` import, which will either map to `pep8` itself or to `pycodestyle` depending on what Flake8 is using. This **changes the dependency from `pep8` to `flake8`** and in theory `pep8` could be uninstalled (if not used by Flake8). As this is actually a Flake8 plugin, I don't think it is a large issue, but maybe I'm missing something so I have highlighted it here.

This is part of #37, so it will only work on Flake8 2.x. There is a bug report on [Flake8 3.x](https://gitlab.com/pycqa/flake8/issues/161), as that seems to not use `pycodestyle`'s value and thus it'll return an empty string. But as 3.x is only beta, supporting that is not as urgent as supporting 2.x.

And the remaining changes of #37 won't change anything in the handling of Flake8 2.x but just add support for 3.x, so the idea of this patch would still be required.