### PR TITLE
Require valid parameter choice

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -54,10 +54,12 @@ class QuoteChecker(object):
     @classmethod
     def add_options(cls, parser):
         cls._register_opt(parser, '--quotes', action='store',
-                          parse_from_config=True,
+                          parse_from_config=True, type='choice',
+                          choices=list(cls.INLINE_QUOTES),
                           help='Deprecated alias for `--inline-quotes`')
         cls._register_opt(parser, '--inline-quotes', default='\'',
                           action='store', parse_from_config=True,
+                          type='choice', choices=list(cls.INLINE_QUOTES),
                           help='Quote to expect in all files (default: \')')
 
     @classmethod

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -55,11 +55,11 @@ class QuoteChecker(object):
     def add_options(cls, parser):
         cls._register_opt(parser, '--quotes', action='store',
                           parse_from_config=True, type='choice',
-                          choices=list(cls.INLINE_QUOTES),
+                          choices=sorted(cls.INLINE_QUOTES.keys()),
                           help='Deprecated alias for `--inline-quotes`')
         cls._register_opt(parser, '--inline-quotes', default='\'',
-                          action='store', parse_from_config=True,
-                          type='choice', choices=list(cls.INLINE_QUOTES),
+                          action='store', parse_from_config=True, type='choice',
+                          choices=sorted(cls.INLINE_QUOTES.keys()),
                           help='Quote to expect in all files (default: \')')
 
     @classmethod


### PR DESCRIPTION
The `--quotes` and `--inline-quotes` options require a value of a set of certain choices.

This is basically extracted from #33, but uses the dict supplied instead. I originally couldn't extract it because #33 would introduce lists instead of dicts, so calling `list()` wouldn't be necessary and so it would unnecessarily break `git blame`. But the discussion in #26 showed that it might be sensible to use dicts to map the chosen value to the actual used value. While this is not necessary at the moment for inline quotes, the multiline quotes profit from that.

Unfortunately I was unable to write a test as `optparse` by default doesn't actually verify the choice. So I'd have to manually call the check for each value. Maybe it is possible to use `flake8` somehow but for now this should suffice.