### PR TITLE
Use flake8-polyfill to support Flake8 2.x and 3.x

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -2,7 +2,16 @@ import optparse
 import tokenize
 import warnings
 
-from flake8.engine import pep8
+from flake8_polyfill import stdin, version
+
+# Choose correct pep8/pycodestyle package depending on Flake8
+if version.version_info < (2, 6):
+    import pep8
+else:
+    # Flake8 2.x monkey patchs it automatically
+    if version.version_info >= (3, 0):
+        stdin.monkey_patch('pycodestyle')
+    import pycodestyle as pep8
 
 from flake8_quotes.__about__ import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     version=about['__version__'],
     install_requires=[
         'flake8',
+        'flake8-polyfill',
     ],
     url='http://github.com/zheller/flake8-quotes/',
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
As Flake8 2.6 switched from `pep8` to `pycodestyle` so that using `pep8` itself doesn't help. So with 09198d1e the plugin imported `flake8.engine.pep8` which is either one of them depending on the version. But Flake8 3.x doesn't have this package anymore so it broke support for Flake8 3.x then.

This is redesigning the import to use `flake8-polyfill` which provides an easily handleable version number. So instead of using `flake8.engine.pep8` it is comparing the version number and based on that either imports `pep8` or `pycodestyle`. But additionally to that it needs to monkey patch the stdin function in Flake8 3.x into that package.

It enables the test using Flake8's stdin functionality on Flake8 3.x. It also adds a test to use Flake8 on a file.