### PR TITLE
Use proper entry point name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     entry_points={
         'flake8.extension': [
-            'flake8_quotes = flake8_quotes:QuoteChecker',
+            'Q000 = flake8_quotes:QuoteChecker',
         ],
     },
     license='MIT',

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -27,9 +27,7 @@ class TestFlake8Stdin(TestCase):
         """Test using stdin."""
         filepath = get_absolute_path('data/doubles.py')
         with open(filepath, 'rb') as f:
-            # For some reason using "--select=Q" did suppress all outputs, so
-            # the result might contain non flake_quotes related errors
-            p = subprocess.Popen(['flake8', '-'], stdin=f,
+            p = subprocess.Popen(['flake8', '--select=Q', '-'], stdin=f,
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
 


### PR DESCRIPTION
The entry point must be of the form `errorcode = target` so that it is possible to select the plugin explicitly in Flake8 2.x and implicitly in Flake8 3.x.

The following commands would've yielded no errors from this plugin without the change. In Flake8 2.x it wasn't possible to select it:

    flake8 --select=Q FILES

In Flake8 3.x (if the code has been made compatible again) it wasn't selected by default without the user explicitly selecting it:

    flake8 FILES

Calling the command in the other Flake8 version would have worked. See also https://gitlab.com/pycqa/flake8/issues/183