### PR TITLE
Repaired Flake8==3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip install -r requirements-dev.txt
 
   # If we are testing Flake8 3.x, then install it
-  - if test "$FLAKE8_VERSION" = "3"; then pip install flake8==3.0.0b2; fi
+  - if test "$FLAKE8_VERSION" = "3"; then pip install flake8==3; fi
 
   # Install `flake8-quotes`
   - python setup.py develop

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -2,7 +2,17 @@ import optparse
 import tokenize
 import warnings
 
-from flake8.engine import pep8
+# Polyfill stdin loading/reading lines
+# https://gitlab.com/pycqa/flake8-polyfill/blob/1.0.1/src/flake8_polyfill/stdin.py#L52-57
+try:
+    from flake8.engine import pep8
+    stdin_get_value = pep8.stdin_get_value
+    readlines = pep8.readlines
+except ImportError:
+    from flake8 import utils
+    import pycodestyle
+    stdin_get_value = utils.stdin_get_value
+    readlines = pycodestyle.readlines
 
 from flake8_quotes.__about__ import __version__
 
@@ -74,9 +84,9 @@ class QuoteChecker(object):
 
     def get_file_contents(self):
         if self.filename in ('stdin', '-', None):
-            return pep8.stdin_get_value().splitlines(True)
+            return stdin_get_value().splitlines(True)
         else:
-            return pep8.readlines(self.filename)
+            return readlines(self.filename)
 
     def run(self):
         file_contents = self.get_file_contents()

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -1,18 +1,7 @@
 from flake8_quotes import QuoteChecker
 import os
 import subprocess
-from unittest import expectedFailure, TestCase
-
-
-FLAKE8_VERSION = os.environ.get('FLAKE8_VERSION', '2')
-
-
-def expectedFailureIf(condition):
-    """Only expect failure if condition applies."""
-    if condition:
-        return expectedFailure
-    else:
-        return lambda func: func
+from unittest import TestCase
 
 
 class TestChecks(TestCase):
@@ -22,7 +11,6 @@ class TestChecks(TestCase):
 
 
 class TestFlake8Stdin(TestCase):
-    @expectedFailureIf(FLAKE8_VERSION == '3')
     def test_stdin(self):
         """Test using stdin."""
         filepath = get_absolute_path('data/doubles.py')
@@ -33,11 +21,10 @@ class TestFlake8Stdin(TestCase):
 
         stdout_lines = stdout.splitlines()
         self.assertEqual(stderr, b'')
-        self.assertEqual(stdout_lines, [
-            b'stdin:1:25: Q000 Remove bad quotes.',
-            b'stdin:2:25: Q000 Remove bad quotes.',
-            b'stdin:3:25: Q000 Remove bad quotes.',
-        ])
+        self.assertEqual(len(stdout_lines), 3)
+        self.assertRegexpMatches(stdout_lines[0], b'stdin:1:(24|25): Q000 Remove bad quotes.')
+        self.assertRegexpMatches(stdout_lines[1], b'stdin:2:(24|25): Q000 Remove bad quotes.')
+        self.assertRegexpMatches(stdout_lines[2], b'stdin:3:(24|25): Q000 Remove bad quotes.')
 
 
 class DoublesTestChecks(TestCase):


### PR DESCRIPTION
This PR repairs #29 and supercedes #44 by using less lines of code and reducing overall noise. In this PR:

- Moved to installing `flake8==3` in Travis CI
- Moved to `try/except` for loading `pep8` and `pycodestyle`
    - Attribution to @xZise in #44 for pointing out that we can use `pycodestyle` as an alternate to reading files
- Fixed #29 

/cc @zheller @xZise 