### PR TITLE
Added alias support for Windows CLI support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,13 @@ By default, we expect single quotes (') and look for unwanted double quotes (").
 .. code:: shell
 
     flake8 --inline-quotes '"'
+    # We also support "double" and "single"
+    # flake8 --inline-quotes 'double'
 
 or configuration option in `tox.ini`/`setup.cfg`.
 
 .. code:: ini
 
     inline-quotes = "
+    # We also support "double" and "single"
+    # inline-quotes = double

--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -36,6 +36,10 @@ class QuoteChecker(object):
             'bad_multiline': '\'\'\'',
         },
     }
+    # Provide aliases for Windows CLI support
+    #   https://github.com/zheller/flake8-quotes/issues/49
+    INLINE_QUOTES['single'] = INLINE_QUOTES['\'']
+    INLINE_QUOTES['double'] = INLINE_QUOTES['"']
 
     def __init__(self, tree, filename='(none)', builtins=None):
         self.filename = filename

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -54,6 +54,24 @@ class DoublesTestChecks(TestCase):
         self.assertEqual(list(checker.run()), [])
 
 
+class DoublesAliasTestChecks(TestCase):
+    def setUp(self):
+        class DoublesAliasOptions():
+            inline_quotes = 'single'
+        QuoteChecker.parse_options(DoublesAliasOptions)
+
+    def test_doubles(self):
+        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_wrapped.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [])
+
+        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
+            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes.'},
+        ])
+
+
 class SinglesTestChecks(TestCase):
     def setUp(self):
         class SinglesOptions():
@@ -79,6 +97,24 @@ class SinglesTestChecks(TestCase):
     def test_noqa_singles(self):
         checker = QuoteChecker(None, get_absolute_path('data/singles_noqa.py'))
         self.assertEqual(list(checker.run()), [])
+
+
+class SinglesAliasTestChecks(TestCase):
+    def setUp(self):
+        class SinglesAliasOptions():
+            inline_quotes = 'double'
+        QuoteChecker.parse_options(SinglesAliasOptions)
+
+    def test_singles(self):
+        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_wrapped.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [])
+
+        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
+            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes.'},
+        ])
 
 
 def get_absolute_path(filepath):


### PR DESCRIPTION
In #49, we received a report of Windows not supporting our CLI options. After some triage, we confirmed that this was true and there are no plausible workarounds. To remedy this, we think adding aliases for `inline-quotes` is a reasonable idea (e.g. `--inline-quotes double`). In this PR:

- Added aliases for `inline-quotes` options
- Added tests
- Added documentation

/cc @zheller 