### PR TITLE
Corrected default setup for multiline quotes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,3 @@ max-line-length = 120
 # Force jobs to 1 as a workaround to avoid the PicklingError in Flake8 3.x
 # see https://gitlab.com/pycqa/flake8/issues/164
 jobs=1
-
-# Configure our quotes
-inline-quotes = '
-multiline-quotes = """

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -31,6 +31,7 @@ class DoublesTestChecks(TestCase):
     def setUp(self):
         class DoublesOptions():
             inline_quotes = '\''
+            multiline_quotes = '\''
         QuoteChecker.parse_options(DoublesOptions)
 
     def test_multiline_string(self):
@@ -60,6 +61,7 @@ class DoublesAliasTestChecks(TestCase):
     def setUp(self):
         class DoublesAliasOptions():
             inline_quotes = 'single'
+            multiline_quotes = 'single'
         QuoteChecker.parse_options(DoublesAliasOptions)
 
     def test_doubles(self):
@@ -78,6 +80,7 @@ class SinglesTestChecks(TestCase):
     def setUp(self):
         class SinglesOptions():
             inline_quotes = '"'
+            multiline_quotes = '"'
         QuoteChecker.parse_options(SinglesOptions)
 
     def test_multiline_string(self):
@@ -107,6 +110,7 @@ class SinglesAliasTestChecks(TestCase):
     def setUp(self):
         class SinglesAliasOptions():
             inline_quotes = 'double'
+            multiline_quotes = 'double'
         QuoteChecker.parse_options(SinglesAliasOptions)
 
     def test_singles(self):


### PR DESCRIPTION
After releasing, I realized that we had broken our default config so we probably broke other's too. In this PR:

- Corrected default setup for multiline quotes to be """
- Updated tests to use appropriate `0.10.0` legacy  for multiline tests
- Updated CLI description to use """