### PR TITLE
Naively implement Q001 for multiline strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     include_package_data=True,
     entry_points={
         'flake8.extension': [
-            'Q000 = flake8_quotes:QuoteChecker',
+            'Q0 = flake8_quotes:QuoteChecker',
         ],
     },
     license='MIT',

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -37,7 +37,7 @@ class DoublesTestChecks(TestCase):
     def test_multiline_string(self):
         doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_multiline_string.py'))
         self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
-            {'col': 0, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string.'},
         ])
 
     def test_wrapped(self):
@@ -86,7 +86,7 @@ class SinglesTestChecks(TestCase):
     def test_multiline_string(self):
         singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_multiline_string.py'))
         self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
-            {'col': 0, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string.'},
         ])
 
     def test_wrapped(self):
@@ -135,7 +135,7 @@ class MultilineTestChecks(TestCase):
 
         multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
         self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
-            {'col': 0, 'line': 5, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 0, 'line': 5, 'message': 'Q001 Remove bad quotes from multiline string.'},
         ])
 
     def test_singles_alias(self):
@@ -146,7 +146,7 @@ class MultilineTestChecks(TestCase):
 
         multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
         self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
-            {'col': 0, 'line': 5, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 0, 'line': 5, 'message': 'Q001 Remove bad quotes from multiline string.'},
         ])
 
     def test_doubles(self):
@@ -157,7 +157,7 @@ class MultilineTestChecks(TestCase):
 
         multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
         self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
-            {'col': 0, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string.'},
         ])
 
     def test_doubles_alias(self):
@@ -168,7 +168,7 @@ class MultilineTestChecks(TestCase):
 
         multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
         self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
-            {'col': 0, 'line': 1, 'message': 'Q000 Remove bad quotes.'},
+            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string.'},
         ])
 
 


### PR DESCRIPTION
This is very naive implementation, but I think it's a good first step. A little bit of change to the logic, but it makes a bit more sense now I think. It passes all the existing tests.
What I'm planning to do next is to replace the tokenize library with the ast module, as this will allow us to recognize docstrings and generally give us more flexibility in the checks. I still don't know how that will play with py2.
Not sure if I need to add that to entry_points in setup.py