### PR TITLE
Moved to twine for upload

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -31,4 +31,5 @@ git push
 git push --tags
 
 # Publish the release to PyPI
-python setup.py sdist --formats=gztar,zip upload
+python setup.py sdist --formats=gztar
+twine upload "dist/flake8-quotes-$version.tar.gz"


### PR DESCRIPTION
PyPI has dropped support for uploading via `setup.py upload` due to security concerns. The recommended alternative is to use `twine`:

https://packaging.python.org/tutorials/distributing-packages/#uploading-your-project-to-pypi

In this PR:

- Updated `release.sh` to use `twine`