### PR TITLE
Added a note about escaping quotes in the doc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,13 @@ or configuration option in `tox.ini`/`setup.cfg`.
     # multiline-quotes = '
     # We also support "'''"
     # multiline-quotes = '''
+
+Caveats
+-------
+
+We follow the `PEP8 conventions <https://www.python.org/dev/peps/pep-0008/#string-quotes>`_ to avoid backslashes in the string. So, no matter what configuration you are using (single or double quotes) these are always valid strings
+
+.. code:: python
+
+    s = 'double "quotes" wrapped in singles are ignored'
+    s = "single 'quotes' wrapped in doubles are ignored"


### PR DESCRIPTION
To avoid surprises to the users I think that it will be a good idea explain in the doc that _wrapped_ quotes are always valid.

I make this PR with a suggestion about the explanation test. Feel free to close the pull and write the message that you think is better.

BTW, great plugin.