### PR TITLE
Fix stdin handling: use lines instead of filename

### DIFF
--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -6,8 +6,8 @@ from unittest import TestCase
 
 class TestChecks(TestCase):
     def test_get_noqa_lines(self):
-        checker = QuoteChecker(None, filename=get_absolute_path('data/no_qa.py'))
-        self.assertEqual(checker.get_noqa_lines(checker.get_file_contents()), [2])
+        checker = QuoteChecker(None, lines=get_lines('data/no_qa.py'))
+        self.assertEqual(checker.get_noqa_lines(), [2])
 
 
 class TestFlake8Stdin(TestCase):
@@ -35,18 +35,18 @@ class DoublesTestChecks(TestCase):
         QuoteChecker.parse_options(DoublesOptions)
 
     def test_multiline_string(self):
-        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_multiline_string.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
+        doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles_multiline_string.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors()), [
             {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
         ])
 
     def test_wrapped(self):
-        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_wrapped.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [])
+        doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles_wrapped.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors()), [])
 
     def test_doubles(self):
-        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
+        doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors()), [
             {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
@@ -65,11 +65,11 @@ class DoublesAliasTestChecks(TestCase):
         QuoteChecker.parse_options(DoublesAliasOptions)
 
     def test_doubles(self):
-        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles_wrapped.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [])
+        doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles_wrapped.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors()), [])
 
-        doubles_checker = QuoteChecker(None, filename=get_absolute_path('data/doubles.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors(doubles_checker.get_file_contents())), [
+        doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles.py'))
+        self.assertEqual(list(doubles_checker.get_quotes_errors()), [
             {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
@@ -84,18 +84,18 @@ class SinglesTestChecks(TestCase):
         QuoteChecker.parse_options(SinglesOptions)
 
     def test_multiline_string(self):
-        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_multiline_string.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
+        singles_checker = QuoteChecker(None, lines=get_lines('data/singles_multiline_string.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors()), [
             {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
         ])
 
     def test_wrapped(self):
-        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_wrapped.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [])
+        singles_checker = QuoteChecker(None, lines=get_lines('data/singles_wrapped.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors()), [])
 
     def test_singles(self):
-        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
+        singles_checker = QuoteChecker(None, lines=get_lines('data/singles.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors()), [
             {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
@@ -114,11 +114,11 @@ class SinglesAliasTestChecks(TestCase):
         QuoteChecker.parse_options(SinglesAliasOptions)
 
     def test_singles(self):
-        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles_wrapped.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [])
+        singles_checker = QuoteChecker(None, lines=get_lines('data/singles_wrapped.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors()), [])
 
-        singles_checker = QuoteChecker(None, filename=get_absolute_path('data/singles.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors(singles_checker.get_file_contents())), [
+        singles_checker = QuoteChecker(None, lines=get_lines('data/singles.py'))
+        self.assertEqual(list(singles_checker.get_quotes_errors()), [
             {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
             {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
@@ -132,8 +132,8 @@ class MultilineTestChecks(TestCase):
             multiline_quotes = '"'
         QuoteChecker.parse_options(Options)
 
-        multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
+        multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
+        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
             {'col': 0, 'line': 10, 'message': 'Q001 Remove bad quotes from multiline string'},
         ])
 
@@ -143,8 +143,8 @@ class MultilineTestChecks(TestCase):
             multiline_quotes = 'double'
         QuoteChecker.parse_options(Options)
 
-        multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
+        multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
+        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
             {'col': 0, 'line': 10, 'message': 'Q001 Remove bad quotes from multiline string'},
         ])
 
@@ -154,8 +154,8 @@ class MultilineTestChecks(TestCase):
             multiline_quotes = '\''
         QuoteChecker.parse_options(Options)
 
-        multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
+        multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
+        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
             {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
         ])
 
@@ -165,11 +165,15 @@ class MultilineTestChecks(TestCase):
             multiline_quotes = 'single'
         QuoteChecker.parse_options(Options)
 
-        multiline_checker = QuoteChecker(None, filename=get_absolute_path('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors(multiline_checker.get_file_contents())), [
+        multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
+        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
             {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
         ])
 
 
 def get_absolute_path(filepath):
     return os.path.join(os.path.dirname(__file__), filepath)
+
+
+def get_lines(filepath):
+    return open(get_absolute_path(filepath)).readlines()

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -7,6 +7,7 @@ from unittest import TestCase
 class TestChecks(TestCase):
     def test_get_noqa_lines(self):
         checker = QuoteChecker(None, lines=get_lines('data/no_qa.py'))
+        list(checker.run())
         self.assertEqual(checker.get_noqa_lines(), [2])
 
 
@@ -36,20 +37,20 @@ class DoublesTestChecks(TestCase):
 
     def test_multiline_string(self):
         doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles_multiline_string.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors()), [
-            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
+        self.assertEqual(list(doubles_checker.run()), [
+            (1, 0, 'Q001 Remove bad quotes from multiline string', QuoteChecker),
         ])
 
     def test_wrapped(self):
         doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles_wrapped.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors()), [])
+        self.assertEqual(list(doubles_checker.run()), [])
 
     def test_doubles(self):
         doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors()), [
-            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
+        self.assertEqual(list(doubles_checker.run()), [
+            (1, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (2, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (3, 24, 'Q000 Remove bad quotes', QuoteChecker),
         ])
 
     def test_noqa_doubles(self):
@@ -66,13 +67,13 @@ class DoublesAliasTestChecks(TestCase):
 
     def test_doubles(self):
         doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles_wrapped.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors()), [])
+        self.assertEqual(list(doubles_checker.run()), [])
 
         doubles_checker = QuoteChecker(None, lines=get_lines('data/doubles.py'))
-        self.assertEqual(list(doubles_checker.get_quotes_errors()), [
-            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
+        self.assertEqual(list(doubles_checker.run()), [
+            (1, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (2, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (3, 24, 'Q000 Remove bad quotes', QuoteChecker),
         ])
 
 
@@ -85,20 +86,20 @@ class SinglesTestChecks(TestCase):
 
     def test_multiline_string(self):
         singles_checker = QuoteChecker(None, lines=get_lines('data/singles_multiline_string.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors()), [
-            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
+        self.assertEqual(list(singles_checker.run()), [
+            (1, 0, 'Q001 Remove bad quotes from multiline string', QuoteChecker),
         ])
 
     def test_wrapped(self):
         singles_checker = QuoteChecker(None, lines=get_lines('data/singles_wrapped.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors()), [])
+        self.assertEqual(list(singles_checker.run()), [])
 
     def test_singles(self):
         singles_checker = QuoteChecker(None, lines=get_lines('data/singles.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors()), [
-            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
+        self.assertEqual(list(singles_checker.run()), [
+            (1, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (2, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (3, 24, 'Q000 Remove bad quotes', QuoteChecker),
         ])
 
     def test_noqa_singles(self):
@@ -115,13 +116,13 @@ class SinglesAliasTestChecks(TestCase):
 
     def test_singles(self):
         singles_checker = QuoteChecker(None, lines=get_lines('data/singles_wrapped.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors()), [])
+        self.assertEqual(list(singles_checker.run()), [])
 
         singles_checker = QuoteChecker(None, lines=get_lines('data/singles.py'))
-        self.assertEqual(list(singles_checker.get_quotes_errors()), [
-            {'col': 24, 'line': 1, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 2, 'message': 'Q000 Remove bad quotes'},
-            {'col': 24, 'line': 3, 'message': 'Q000 Remove bad quotes'},
+        self.assertEqual(list(singles_checker.run()), [
+            (1, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (2, 24, 'Q000 Remove bad quotes', QuoteChecker),
+            (3, 24, 'Q000 Remove bad quotes', QuoteChecker),
         ])
 
 
@@ -133,8 +134,8 @@ class MultilineTestChecks(TestCase):
         QuoteChecker.parse_options(Options)
 
         multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
-            {'col': 0, 'line': 10, 'message': 'Q001 Remove bad quotes from multiline string'},
+        self.assertEqual(list(multiline_checker.run()), [
+            (10, 0, 'Q001 Remove bad quotes from multiline string', QuoteChecker),
         ])
 
     def test_singles_alias(self):
@@ -144,8 +145,8 @@ class MultilineTestChecks(TestCase):
         QuoteChecker.parse_options(Options)
 
         multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
-            {'col': 0, 'line': 10, 'message': 'Q001 Remove bad quotes from multiline string'},
+        self.assertEqual(list(multiline_checker.run()), [
+            (10, 0, 'Q001 Remove bad quotes from multiline string', QuoteChecker),
         ])
 
     def test_doubles(self):
@@ -155,8 +156,8 @@ class MultilineTestChecks(TestCase):
         QuoteChecker.parse_options(Options)
 
         multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
-            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
+        self.assertEqual(list(multiline_checker.run()), [
+            (1, 0, 'Q001 Remove bad quotes from multiline string', QuoteChecker),
         ])
 
     def test_doubles_alias(self):
@@ -166,8 +167,8 @@ class MultilineTestChecks(TestCase):
         QuoteChecker.parse_options(Options)
 
         multiline_checker = QuoteChecker(None, lines=get_lines('data/multiline_string.py'))
-        self.assertEqual(list(multiline_checker.get_quotes_errors()), [
-            {'col': 0, 'line': 1, 'message': 'Q001 Remove bad quotes from multiline string'},
+        self.assertEqual(list(multiline_checker.run()), [
+            (1, 0, 'Q001 Remove bad quotes from multiline string', QuoteChecker),
         ])
 
 


### PR DESCRIPTION
flake8 passes through `--stdin-display-name` for the filename, which is
typically not readable.

Ref: https://github.com/gforcada/flake8-isort/pull/48