### PR TITLE
Added quadruple quote ending support

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -42,10 +42,12 @@ class QuoteChecker(object):
     MULTILINE_QUOTES = {
         '\'': {
             'good_multiline': '\'\'\'',
+            'good_multiline_ending': '\'"""',
             'bad_multiline': '"""',
         },
         '"': {
             'good_multiline': '"""',
+            'good_multiline_ending': '"\'\'\'',
             'bad_multiline': '\'\'\'',
         },
     }
@@ -230,6 +232,12 @@ class QuoteChecker(object):
                 #   '''foo(""")''' -> good (continue)
                 #   (''')foo''' -> possibly bad
                 if self.config['good_multiline'] in unprefixed_string:
+                    continue
+
+                # If our string ends with a known good ending, then ignore it
+                #   '''foo("''') -> good (continue)
+                #     Opposite, """foo"""", would break our parser (cannot handle """" ending)
+                if unprefixed_string.endswith(self.config['good_multiline_ending']):
                     continue
 
                 # Output our error

--- a/test/data/doubles_multiline_string.py
+++ b/test/data/doubles_multiline_string.py
@@ -1,7 +1,9 @@
 s = """ This "should"
-"not" be
+be
 "linted" """
 
 s = ''' This "should"
 "not" be
-linted "either" '''
+"linted" '''
+
+s = """'This should not be linted due to having would-be quadruple end quote'"""

--- a/test/data/singles_multiline_string.py
+++ b/test/data/singles_multiline_string.py
@@ -1,7 +1,9 @@
 s = ''' This 'should'
-'not' be
+be
 'linted' '''
 
 s = """ This 'should'
 'not' be
-linted 'either' """
+'linted' """
+
+s = '''"This should not be linted due to having would-be quadruple end quote"'''


### PR DESCRIPTION
As reported by @Zoynels in #95, we've got a damned if we do/damned if we don't scenario for quadruple quote endings in strings

We want a string which has contents `foo"` in the end of a multiline string

If we use double quotes, then the Python parser breaks:

```
>>> a = """ "hi""""
  File "<stdin>", line 1
    a = """ "hi""""
                  ^
SyntaxError: EOL while scanning string literal
```

If we use single quotes, then `flake8-quotes` complains as it doesn't see its desired `"""`

```python
a = ''' "hi"'''
#  Q001 Remove bad quotes from multiline string
```

As a result, we've added an explicit exception for this scenario

In this PR:

- Added quadruple quote definitions and exception
- Added tests
- Fixes #95 

@zheller @Zoynels Once one of you reviews/approves, then I'll land this PR