### PR TITLE
Fixed mistaking key access as docstring

### DIFF
--- a/flake8_quotes/docstring_detection.py
+++ b/flake8_quotes/docstring_detection.py
@@ -63,8 +63,14 @@ def get_docstring_tokens(tokens):
         # Count opening and closing brackets in bracket_count
         elif token.type == tokenize.OP and token.string in ['(', '[', '{']:
             bracket_count += 1
+            if state in [STATE_EXPECT_MODULE_DOCSTRING, STATE_EXPECT_CLASS_DOCSTRING,
+                         STATE_EXPECT_FUNCTION_DOCSTRING]:
+                state = STATE_OTHER
         elif token.type == tokenize.OP and token.string in [')', ']', '}']:
             bracket_count -= 1
+            if state in [STATE_EXPECT_MODULE_DOCSTRING, STATE_EXPECT_CLASS_DOCSTRING,
+                         STATE_EXPECT_FUNCTION_DOCSTRING]:
+                state = STATE_OTHER
         # The token is not one of the recognized types. If we're expecting a colon, then all good,
         # but if we're expecting a docstring, it would no longer be a docstring
         elif state in [STATE_EXPECT_MODULE_DOCSTRING, STATE_EXPECT_CLASS_DOCSTRING,

--- a/test/data/docstring_not_docstrings.py
+++ b/test/data/docstring_not_docstrings.py
@@ -38,3 +38,7 @@ if var0 < 10:
 # https://github.com/zheller/flake8-quotes/issues/97
 def test():
     {}["a"]
+
+
+class test:
+    {}["a"]

--- a/test/data/docstring_not_docstrings.py
+++ b/test/data/docstring_not_docstrings.py
@@ -34,3 +34,7 @@ if var0 < 10:
         not a multiline docstring
     '''
     pass
+
+# https://github.com/zheller/flake8-quotes/issues/97
+def test():
+    {}["a"]


### PR DESCRIPTION
As reported in #97, we were mistaking key access on the first line of functions as docstrings. This PR fixes that with a patch via @oxitnik. In this PR:

- Added fix to stop recognizing key access on the first line of functions/modules/classes as docstrings
- Fixes #97 