### PR TITLE
Update add_options for flake8 6.0

### DIFF
--- a/flake8_quotes/__init__.py
+++ b/flake8_quotes/__init__.py
@@ -107,19 +107,19 @@ class QuoteChecker(object):
     @classmethod
     def add_options(cls, parser):
         cls._register_opt(parser, '--quotes', action='store',
-                          parse_from_config=True, type='choice',
+                          parse_from_config=True,
                           choices=sorted(cls.INLINE_QUOTES.keys()),
                           help='Deprecated alias for `--inline-quotes`')
         cls._register_opt(parser, '--inline-quotes', default="'",
-                          action='store', parse_from_config=True, type='choice',
+                          action='store', parse_from_config=True,
                           choices=sorted(cls.INLINE_QUOTES.keys()),
                           help="Quote to expect in all files (default: ')")
         cls._register_opt(parser, '--multiline-quotes', default=None, action='store',
-                          parse_from_config=True, type='choice',
+                          parse_from_config=True,
                           choices=sorted(cls.MULTILINE_QUOTES.keys()),
                           help='Quote to expect in all files (default: """)')
         cls._register_opt(parser, '--docstring-quotes', default=None, action='store',
-                          parse_from_config=True, type='choice',
+                          parse_from_config=True,
                           choices=sorted(cls.DOCSTRING_QUOTES.keys()),
                           help='Quote to expect in all files (default: """)')
         cls._register_opt(parser, '--avoid-escape', default=None, action='store_true',


### PR DESCRIPTION
This seems to make `flake8-quotes` work with `flake8` 6 for me, i.e. tests pass and projects lint without crashes. For details
https://flake8.pycqa.org/en/latest/release-notes/6.0.0.html#backwards-incompatible-changes

Fixes #110 