### PR TITLE
test: run flake8 with custom cfg to make it aware of flake8_quotes

### DIFF
--- a/test/flake8.cfg
+++ b/test/flake8.cfg
@@ -1,0 +1,5 @@
+[flake8:local-plugins]
+extension =
+    Q0 = flake8_quotes:QuoteChecker
+paths =
+    .

--- a/test/test_checks.py
+++ b/test/test_checks.py
@@ -14,8 +14,9 @@ class TestFlake8Stdin(TestCase):
     def test_stdin(self):
         """Test using stdin."""
         filepath = get_absolute_path('data/doubles.py')
+        flakecfg = get_absolute_path('flake8.cfg')
         with open(filepath, 'rb') as f:
-            p = subprocess.Popen(['flake8', '--select=Q', '-'], stdin=f,
+            p = subprocess.Popen(['flake8', '--config', flakecfg, '--select=Q', '-'], stdin=f,
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
 


### PR DESCRIPTION
Otherwise flake8 might run without the flake8-quotes extension and doesn't report anything:

```
root@e519011a98e7:/code# flake8 --select=Q - < test/data/doubles.py
root@e519011a98e7:/code#
```

Only when the flake8-quotes package is around, it behaves as expected:

```
root@e519011a98e7:/code# pip install --break-system-packages -e .
[...]
root@e519011a98e7:/code# flake8 --select=Q - < test/data/doubles.py 
stdin:1:25: Q000 Double quotes found but single quotes preferred
stdin:2:25: Q000 Double quotes found but single quotes preferred
stdin:3:25: Q000 Double quotes found but single quotes preferred
```

E.g. during a Debian package build we don't have the flake8-quotes package installed, though we can make flake8 aware of the local plugin through a configuration file.

Fixes:

```
| Traceback (most recent call last):
|   File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.12/build/test/test_checks.py", line 24, in test_stdin
|     self.assertEqual(len(stdout_lines), 3)
| AssertionError: 0 != 3
```

Closes: https://github.com/zheller/flake8-quotes/issues/122
Thanks: @zeha for assistance